### PR TITLE
(1-1)管理者登録後の遷移を、従業員一覧からログイン画面に修正

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -77,7 +77,7 @@ public class AdministratorController {
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
 		administratorService.insert(administrator);
-		return toLogin();
+		return "redirect:/";
 	}
 
 	/////////////////////////////////////////////////////

--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -18,7 +18,7 @@ import jakarta.servlet.http.HttpSession;
 
 /**
  * 管理者情報を操作するコントローラー.
- * 
+ *
  * @author igamasayuki
  *
  */
@@ -34,7 +34,7 @@ public class AdministratorController {
 
 	/**
 	 * 使用するフォームオブジェクトをリクエストスコープに格納する.
-	 * 
+	 *
 	 * @return フォーム
 	 */
 	@ModelAttribute
@@ -44,7 +44,7 @@ public class AdministratorController {
 
 	/**
 	 * 使用するフォームオブジェクトをリクエストスコープに格納する.
-	 * 
+	 *
 	 * @return フォーム
 	 */
 	@ModelAttribute
@@ -57,7 +57,7 @@ public class AdministratorController {
 	/////////////////////////////////////////////////////
 	/**
 	 * 管理者登録画面を出力します.
-	 * 
+	 *
 	 * @return 管理者登録画面
 	 */
 	@GetMapping("/toInsert")
@@ -67,7 +67,7 @@ public class AdministratorController {
 
 	/**
 	 * 管理者情報を登録します.
-	 * 
+	 *
 	 * @param form 管理者情報用フォーム
 	 * @return ログイン画面へリダイレクト
 	 */
@@ -77,7 +77,7 @@ public class AdministratorController {
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
 		administratorService.insert(administrator);
-		return "employee/list";
+		return toLogin();
 	}
 
 	/////////////////////////////////////////////////////
@@ -85,7 +85,7 @@ public class AdministratorController {
 	/////////////////////////////////////////////////////
 	/**
 	 * ログイン画面を出力します.
-	 * 
+	 *
 	 * @return ログイン画面
 	 */
 	@GetMapping("/")
@@ -95,7 +95,7 @@ public class AdministratorController {
 
 	/**
 	 * ログインします.
-	 * 
+	 *
 	 * @param form 管理者情報用フォーム
 	 * @return ログイン後の従業員一覧画面
 	 */
@@ -114,7 +114,7 @@ public class AdministratorController {
 	/////////////////////////////////////////////////////
 	/**
 	 * ログアウトをします. (SpringSecurityに任せるためコメントアウトしました)
-	 * 
+	 *
 	 * @return ログイン画面
 	 */
 	@GetMapping(value = "/logout")


### PR DESCRIPTION
## 概要 :bulb:

管理者登録後に、遷移先を従業員一覧からログイン画面に修正。

## 観点 :eye:

コードに問題がないかの確認をお願いいたします。

## テスト :test_tube:

画面で、管理者登録後にログイン画面に遷移するかの確認。

## 関連する Issue :memo:

なし

## 補足情報 :notes:

なし