### PR TITLE
(1-2)管理者登録時に入力値チェックを追加

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -3,6 +3,8 @@ package com.example.controller;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -68,11 +70,16 @@ public class AdministratorController {
 	/**
 	 * 管理者情報を登録します.
 	 *
-	 * @param form 管理者情報用フォーム
+	 * @param form   管理者情報用フォーム
+	 * @param result バリデーション結果
 	 * @return ログイン画面へリダイレクト
 	 */
 	@PostMapping("/insert")
-	public String insert(InsertAdministratorForm form) {
+	public String insert(@Validated InsertAdministratorForm form, BindingResult result) {
+		if (result.hasErrors()) {
+			return toInsert();
+		}
+
 		Administrator administrator = new Administrator();
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);

--- a/src/main/java/com/example/form/InsertAdministratorForm.java
+++ b/src/main/java/com/example/form/InsertAdministratorForm.java
@@ -1,17 +1,26 @@
 package com.example.form;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 /**
  * 管理者情報登録時に使用するフォーム.
- * 
+ *
  * @author igamasayuki
- * 
+ *
  */
 public class InsertAdministratorForm {
 	/** 名前 */
+	@NotBlank(message = "氏名を入力してください")
 	private String name;
 	/** メールアドレス */
+	@NotBlank(message = "メールアドレスを入力してください")
+	@Email(message = "メールアドレス形式で入力してください")
 	private String mailAddress;
 	/** パスワード */
+	@NotBlank(message = "パスワードを入力してください")
+	@Size(min = 8, message = "パスワードは8文字以上で入力してください")
 	private String password;
 
 	public String getName() {


### PR DESCRIPTION
## 概要 :bulb:

管理者登録の入力値チェックを追加。
┗名前：NotBlank
　メールアドレス：NotBlank,Email
　パスワード：NotBlank,Size(8文字以上)

## 観点 :eye:

コードに問題がないかの確認をお願いいたします。

## テスト :test_tube:

（異常系）
画面で、管理者登録時にエラーが発生するか確認。
氏名：null
メールアドレス：null
パスワード：null & 7文字で入力
→エラーメッセージが出る。

（正常系）
氏名：正常値
メールアドレス：正常値
パスワード：正常値
→ログイン画面に遷移。データベースに登録される。

## 関連する Issue :memo:

なし

## 補足情報 :notes:

なし