### PR TITLE
(1-3)Eメール重複時に500エラーが出る事象の対応

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -77,7 +77,7 @@ public class AdministratorController {
 	@PostMapping("/insert")
 	public String insert(@Validated InsertAdministratorForm form, BindingResult result) {
 		if (administratorService.searchByEmail(form.getMailAddress()) != null) {
-			result.rejectValue("mailAddress", "This email address is already registered.", "既に登録されているメールアドレスです");
+			result.rejectValue("mailAddress", "email.alreadyExists", "既に登録されているメールアドレスです");
 		}
 
 		if (result.hasErrors()) {

--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -4,7 +4,6 @@ import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -77,6 +76,11 @@ public class AdministratorController {
 	 */
 	@PostMapping("/insert")
 	public String insert(@Validated InsertAdministratorForm form, BindingResult result) {
+		if (administratorService.searchByEmail(form.getMailAddress()) != null) {
+			result.rejectValue("mailAddress", "", "既に登録されているメールアドレスです");
+			return toInsert();
+		}
+
 		if (result.hasErrors()) {
 			return toInsert();
 		}
@@ -84,10 +88,6 @@ public class AdministratorController {
 		Administrator administrator = new Administrator();
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
-		if (administratorService.searchByEmail(form.getMailAddress()) != null) {
-			result.addError(new FieldError(result.getObjectName(), "mailAddress", "既に登録されているメールアドレスです"));
-			return toInsert();
-		}
 		administratorService.insert(administrator);
 		return "redirect:/";
 	}

--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -77,8 +77,7 @@ public class AdministratorController {
 	@PostMapping("/insert")
 	public String insert(@Validated InsertAdministratorForm form, BindingResult result) {
 		if (administratorService.searchByEmail(form.getMailAddress()) != null) {
-			result.rejectValue("mailAddress", "", "既に登録されているメールアドレスです");
-			return toInsert();
+			result.rejectValue("mailAddress", "This email address is already registered.", "既に登録されているメールアドレスです");
 		}
 
 		if (result.hasErrors()) {

--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -3,6 +3,9 @@ package com.example.controller;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -72,10 +75,14 @@ public class AdministratorController {
 	 * @return ログイン画面へリダイレクト
 	 */
 	@PostMapping("/insert")
-	public String insert(InsertAdministratorForm form) {
+	public String insert(@Validated InsertAdministratorForm form, BindingResult result) {
 		Administrator administrator = new Administrator();
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
+		if (administratorService.searchByEmail(form.getMailAddress()) != null) {
+			result.addError(new FieldError(result.getObjectName(), "mailAddress", "既に登録されているメールアドレスです"));
+			return toInsert();
+		}
 		administratorService.insert(administrator);
 		return "redirect:/";
 	}

--- a/src/main/java/com/example/service/AdministratorService.java
+++ b/src/main/java/com/example/service/AdministratorService.java
@@ -9,7 +9,7 @@ import com.example.repository.AdministratorRepository;
 
 /**
  * 管理者情報を操作するサービス.
- * 
+ *
  * @author igamasayuki
  *
  */
@@ -22,7 +22,7 @@ public class AdministratorService {
 
 	/**
 	 * 管理者情報を登録します.
-	 * 
+	 *
 	 * @param administrator 管理者情報
 	 */
 	public void insert(Administrator administrator) {
@@ -31,7 +31,7 @@ public class AdministratorService {
 
 	/**
 	 * ログインをします.
-	 * 
+	 *
 	 * @param mailAddress メールアドレス
 	 * @param password    パスワード
 	 * @return 管理者情報 存在しない場合はnullが返ります
@@ -39,5 +39,15 @@ public class AdministratorService {
 	public Administrator login(String mailAddress, String password) {
 		Administrator administrator = administratorRepository.findByMailAddressAndPassward(mailAddress, password);
 		return administrator;
+	}
+
+	/**
+	 * メールアドレスから管理者情報を取得します.
+	 *
+	 * @param mailAddress メールアドレス
+	 * @return 管理者情報 存在しない場合なnullが返ります
+	 */
+	public Administrator searchByEmail(String mailAddress) {
+		return administratorRepository.findByMailAddress(mailAddress);
 	}
 }


### PR DESCRIPTION
## 概要 :bulb:

従業員登録時、既に存在するメールアドレスの場合に500エラーが発生していたため、
ログイン画面に滞在しエラーメッセージを表示する対応を行いました。

## 観点 :eye:

以下問題ないかのご確認をよろしくお願いいたします。
・メールアドレスが存在する場合のロジック
・エラーメッセージの表示方法(resultに独自エラーを作成する方法)

## テスト :test_tube:
（異常系）
既に存在するメールアドレスで登録した際に、エラーが表示されること。

（正常系）
存在しないメールアドレスで登録できること。

## 関連する Issue :memo:

なし

## 補足情報 :notes:

なし