### PR TITLE
(1-5)管理者登録に確認用パスワードを追加

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -77,7 +77,7 @@ public class AdministratorController {
 	@PostMapping("/insert")
 	public String insert(@Validated InsertAdministratorForm form, BindingResult result) {
 		if (!form.getPassword().equals(form.getConfirmPassword())) {
-			result.rejectValue("confirmPassword", null, "パスワードが一致しません");
+			result.rejectValue("confirmPassword", "password.mismatch", "パスワードが一致しません");
 		}
 
 		if (result.hasErrors()) {

--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -76,6 +76,10 @@ public class AdministratorController {
 	 */
 	@PostMapping("/insert")
 	public String insert(@Validated InsertAdministratorForm form, BindingResult result) {
+		if (!form.getPassword().equals(form.getConfirmPassword())) {
+			result.rejectValue("confirmPassword", null, "パスワードが一致しません");
+		}
+
 		if (result.hasErrors()) {
 			return toInsert();
 		}

--- a/src/main/java/com/example/form/InsertAdministratorForm.java
+++ b/src/main/java/com/example/form/InsertAdministratorForm.java
@@ -22,6 +22,9 @@ public class InsertAdministratorForm {
 	@NotBlank(message = "パスワードを入力してください")
 	@Size(min = 8, message = "パスワードは8文字以上で入力してください")
 	private String password;
+	/** 確認用パスワード */
+	@NotBlank(message = "確認用パスワードを入力してください")
+	private String confirmPassword;
 
 	public String getName() {
 		return name;
@@ -47,10 +50,18 @@ public class InsertAdministratorForm {
 		this.password = password;
 	}
 
+	public String getConfirmPassword() {
+		return confirmPassword;
+	}
+
+	public void setConfirmPassword(String confirmPassword) {
+		this.confirmPassword = confirmPassword;
+	}
+
 	@Override
 	public String toString() {
 		return "InsertAdministratorForm [name=" + name + ", mailAddress=" + mailAddress + ", password=" + password
-				+ "]";
+				+ ", confirmPassword=" + confirmPassword + "]";
 	}
 
 }

--- a/src/main/resources/templates/administrator/insert.html
+++ b/src/main/resources/templates/administrator/insert.html
@@ -1,149 +1,116 @@
 <!DOCTYPE html>
 <html lang="ja" xmlns:th="http://www.thymeleaf.org">
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>従業員管理システム</title>
-    <link
-      rel="stylesheet"
-      href="../../static/css/bootstrap.css"
-      th:href="@{/css/bootstrap.css}"
-    />
-    <link
-      rel="stylesheet"
-      href="../../static/css/style.css"
-      th:href="@{/css/style.css}"
-    />
-    <!--[if lt IE 9]>
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>従業員管理システム</title>
+  <link rel="stylesheet" href="../../static/css/bootstrap.css" th:href="@{/css/bootstrap.css}" />
+  <link rel="stylesheet" href="../../static/css/style.css" th:href="@{/css/style.css}" />
+  <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
-  </head>
-  <body>
-    <div class="container">
-      <!-- 上余白 -->
-      <div class="row">
-        <div class="col-lg-offset-0 col-lg-6 col-md-8 col-sm-10 col-xs-12">
-          <img
-            src="../../static/img/header_logo.png"
-            th:src="@{/img/header_logo.png}"
-          />
-        </div>
+</head>
+
+<body>
+  <div class="container">
+    <!-- 上余白 -->
+    <div class="row">
+      <div class="col-lg-offset-0 col-lg-6 col-md-8 col-sm-10 col-xs-12">
+        <img src="../../static/img/header_logo.png" th:src="@{/img/header_logo.png}" />
       </div>
-      <!-- login form -->
-      <div class="row">
-        <div
-          class="col-lg-offset-3 col-lg-6 col-md-offset-2 col-md-8 col-sm-10 col-xs-12"
-        >
-          <!-- 背景をグレーに、埋め込んだようなコンポーネント -->
-          <div class="well">
-            <!-- ここから上を編集する必要はありません -->
+    </div>
+    <!-- login form -->
+    <div class="row">
+      <div class="col-lg-offset-3 col-lg-6 col-md-offset-2 col-md-8 col-sm-10 col-xs-12">
+        <!-- 背景をグレーに、埋め込んだようなコンポーネント -->
+        <div class="well">
+          <!-- ここから上を編集する必要はありません -->
 
-            <!-- ここにモックのform要素を貼り付けます -->
+          <!-- ここにモックのform要素を貼り付けます -->
 
-            <form
-              method="post"
-              action="login.html"
-              th:action="@{/insert}"
-              th:object="${insertAdministratorForm}"
-            >
-              <fieldset>
-                <legend>
-                  管理者登録<br />(システムにログインできる管理者を登録します)
-                </legend>
-                <!-- 氏名 -->
-                <div class="form-group">
-                  <div class="row">
-                    <div class="col-sm-12">
-                      <label for="name"> 氏名: </label>
-                      <label
-                        th:errors="*{name}"
-                        class="error-messages"
-                      >
-                        氏名を入力してください
-                      </label>
-                      <input
-                        type="text"
-                        name="name"
-                        id="name"
-                        class="form-control"
-                        placeholder="山田太郎"
-                        th:field="*{name}"
-                        th:errorclass="error-input"
-                        value="山田太郎"
-                      />
-                    </div>
+          <form method="post" action="login.html" th:action="@{/insert}" th:object="${insertAdministratorForm}">
+            <fieldset>
+              <legend>
+                管理者登録<br />(システムにログインできる管理者を登録します)
+              </legend>
+              <!-- 氏名 -->
+              <div class="form-group">
+                <div class="row">
+                  <div class="col-sm-12">
+                    <label for="name"> 氏名: </label>
+                    <label th:errors="*{name}" class="error-messages">
+                      氏名を入力してください
+                    </label>
+                    <input type="text" name="name" id="name" class="form-control" placeholder="山田太郎" th:field="*{name}"
+                      th:errorclass="error-input" value="山田太郎" />
                   </div>
                 </div>
-                <!-- メールアドレス -->
-                <div class="form-group">
-                  <div class="row">
-                    <div class="col-sm-12">
-                      <label for="mailAddress"> メールアドレス: </label>
-                      <label
-                        th:errors="*{mailAddress}"
-                        class="error-messages"
-                      >
-                        メールアドレスを入力してください
-                      </label>
-                      <input
-                        type="text"
-                        name="mailAddress"
-                        id="mailAddress"
-                        class="form-control"
-                        placeholder="yamada@mail.com"
-                        th:field="*{mailAddress}"
-                        th:errorclass="error-input"
-                        value="yamada@mail.com"
-                      />
-                    </div>
+              </div>
+              <!-- メールアドレス -->
+              <div class="form-group">
+                <div class="row">
+                  <div class="col-sm-12">
+                    <label for="mailAddress"> メールアドレス: </label>
+                    <label th:errors="*{mailAddress}" class="error-messages">
+                      メールアドレスを入力してください
+                    </label>
+                    <input type="text" name="mailAddress" id="mailAddress" class="form-control"
+                      placeholder="yamada@mail.com" th:field="*{mailAddress}" th:errorclass="error-input"
+                      value="yamada@mail.com" />
                   </div>
                 </div>
-                <!-- パスワード -->
-                <div class="form-group">
-                  <div class="row">
-                    <div class="col-sm-12">
-                      <label for="password"> パスワード: </label>
-                      <label
-                        th:errors="*{password}"
-                        class="error-messages"
-                      >
-                        パスワードを入力してください
-                      </label>
-                      <input
-                        type="password"
-                        name="password"
-                        id="password"
-                        class="form-control"
-                        placeholder="password"
-                        th:field="*{password}"
-                        th:errorclass="error-input"
-                        value="xxxxxxxx"
-                      />
-                    </div>
+              </div>
+              <!-- パスワード -->
+              <div class="form-group">
+                <div class="row">
+                  <div class="col-sm-12">
+                    <label for="password"> パスワード: </label>
+                    <label th:errors="*{password}" class="error-messages">
+                      パスワードを入力してください
+                    </label>
+                    <input type="password" name="password" id="password" class="form-control" placeholder="password"
+                      th:field="*{password}" th:errorclass="error-input" value="xxxxxxxx" />
                   </div>
                 </div>
-                <!-- 登録ボタン -->
-                <div class="form-group">
-                  <div class="row">
-                    <div class="col-sm-12">
-                      <button type="submit" class="btn btn-primary">
-                        登録
-                      </button>
-                    </div>
+              </div>
+              <!-- 確認用パスワード -->
+              <div class="form-group">
+                <div class="row">
+                  <div class="col-sm-12">
+                    <label for="confirmPassword"> 確認用パスワード: </label>
+                    <label th:errors="*{confirmPassword}" class="error-messages">
+                      確認用パスワードを入力してください
+                    </label>
+                    <input type="password" name="confirmPassword" id="confirmPassword" class="form-control"
+                      placeholder="password" th:field="*{confirmPassword}" th:errorclass="error-input"
+                      value="xxxxxxxx" />
                   </div>
                 </div>
-              </fieldset>
-            </form>
+              </div>
+              <!-- 登録ボタン -->
+              <div class="form-group">
+                <div class="row">
+                  <div class="col-sm-12">
+                    <button type="submit" class="btn btn-primary">
+                      登録
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </fieldset>
+          </form>
 
-            <!-- ここから下を編集する必要はありません -->
-          </div>
+          <!-- ここから下を編集する必要はありません -->
         </div>
       </div>
     </div>
-    <!-- end container -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="../../static/js/bootstrap.min.js"></script>
-  </body>
+  </div>
+  <!-- end container -->
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+  <script src="../../static/js/bootstrap.min.js"></script>
+</body>
+
 </html>


### PR DESCRIPTION
## 概要 :bulb:

管理者登録フォームに確認用パスワードを追加し、パスワードと一致していない場合はエラーメッセージを表示する。

## 観点 :eye:

コードに問題がないかの確認をお願いいたします。

## テスト :test_tube:

(異常系)
パスワードと確認用パスワードを別々の文字列(8文字以上)で入力する。
→エラーメッセージが出ることを確認。

(正常系)
パスワードと確認用パスワードを同じ文字列(8文字以上)で入力する。
→ログイン画面に遷移すること、登録内容がDBに格納されていることを確認。

## 関連する Issue :memo:

なし

## 補足情報 :notes:

なし