### PR TITLE
(2-1)従業員一覧画面と従業員詳細画面にログインユーザー名を表示させる対応

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -117,6 +117,7 @@ public class AdministratorController {
 			redirectAttributes.addFlashAttribute("errorMessage", "メールアドレスまたはパスワードが不正です。");
 			return "redirect:/";
 		}
+		session.setAttribute("administratorName", administrator.getName());
 		return "redirect:/employee/showList";
 	}
 

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -1,226 +1,159 @@
 <!DOCTYPE html>
-<html
-  lang="ja"
-  xmlns:th="http://www.thymeleaf.org"
-  xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
->
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>従業員管理システム</title>
-    <link
-      rel="stylesheet"
-      href="../../static/css/bootstrap.css"
-      th:href="@{/css/bootstrap.css}"
-    />
-    <link
-      rel="stylesheet"
-      href="../../static/css/style.css"
-      th:href="@{/css/style.css}"
-    />
-    <!--[if lt IE 9]>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>従業員管理システム</title>
+  <link rel="stylesheet" href="../../static/css/bootstrap.css" th:href="@{/css/bootstrap.css}" />
+  <link rel="stylesheet" href="../../static/css/style.css" th:href="@{/css/style.css}" />
+  <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
-  </head>
-  <body>
-    <div class="container">
-      <nav class="navbar navbar-default">
-        <div class="container-fluid">
-          <!-- Brand and toggle get grouped for better mobile display -->
-          <div class="navbar-header">
-            <button
-              type="button"
-              class="navbar-toggle collapsed"
-              data-toggle="collapse"
-              data-target="#bs-example-navbar-collapse-1"
-              aria-expanded="false"
-            >
-              <span class="sr-only">Toggle navigation</span>
-              <span class="icon-bar"></span> <span class="icon-bar"></span>
-              <span class="icon-bar"></span>
-            </button>
-            <a
-              class="navbar-brand"
-              href="list.html"
-              th:href="@{/employee/showList}"
-            >
-              <!-- 企業ロゴ -->
-              <img
-                src="../../static/img/header_logo_small.png"
-                th:src="@{/img/header_logo_small.png}"
-              />
-            </a>
-          </div>
+</head>
 
-          <!-- Collect the nav links, forms, and other content for toggling -->
-          <div
-            class="collapse navbar-collapse"
-            id="bs-example-navbar-collapse-1"
-          >
-            <ul class="nav navbar-nav">
-              <li class="active">
-                <a href="list.html" th:href="@{/employee/showList}"
-                  >従業員管理</a
-                >
-              </li>
-            </ul>
-            <p class="navbar-text navbar-right">
-              <span th:text="${administratorName}">山田太郎</span
-              >さんこんにちは！ &nbsp;&nbsp;&nbsp;
-              <a
-                href="../administrator/login.html"
-                class="navbar-link"
-                th:href="@{/logout}"
-                >ログアウト</a
-              >
-            </p>
-          </div>
-          <!-- /.navbar-collapse -->
+<body>
+  <div class="container">
+    <nav class="navbar navbar-default">
+      <div class="container-fluid">
+        <!-- Brand and toggle get grouped for better mobile display -->
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
+            data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span> <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class="navbar-brand" href="list.html" th:href="@{/employee/showList}">
+            <!-- 企業ロゴ -->
+            <img src="../../static/img/header_logo_small.png" th:src="@{/img/header_logo_small.png}" />
+          </a>
         </div>
-        <!-- /.container-fluid -->
-      </nav>
 
-      <!-- パンくずリスト -->
-      <ol class="breadcrumb">
-        <li>従業員リスト</li>
-        <li class="active">従業員詳細</li>
-      </ol>
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+          <ul class="nav navbar-nav">
+            <li class="active">
+              <a href="list.html" th:href="@{/employee/showList}">従業員管理</a>
+            </li>
+          </ul>
+          <p class="navbar-text navbar-right">
+            <span th:text="${session.administratorName}">山田太郎</span>さんこんにちは！ &nbsp;&nbsp;&nbsp;
+            <a href="../administrator/login.html" class="navbar-link" th:href="@{/logout}">ログアウト</a>
+          </p>
+        </div>
+        <!-- /.navbar-collapse -->
+      </div>
+      <!-- /.container-fluid -->
+    </nav>
 
-      <!-- register form -->
-      <div class="row">
-        <div
-          class="col-lg-offset-2 col-lg-8 col-md-offset-2 col-md-8 col-sm-12 col-xs-12"
-        >
-          <!-- 背景をグレーに、埋め込んだようなコンポーネント -->
-          <div class="well">
-            <!-- ここから上を編集する必要はありません -->
+    <!-- パンくずリスト -->
+    <ol class="breadcrumb">
+      <li>従業員リスト</li>
+      <li class="active">従業員詳細</li>
+    </ol>
 
-            <!-- ここにモックのform要素を貼り付けます -->
+    <!-- register form -->
+    <div class="row">
+      <div class="col-lg-offset-2 col-lg-8 col-md-offset-2 col-md-8 col-sm-12 col-xs-12">
+        <!-- 背景をグレーに、埋め込んだようなコンポーネント -->
+        <div class="well">
+          <!-- ここから上を編集する必要はありません -->
 
-            <form
-              method="post"
-              action="list.html"
-              th:action="@{/employee/update}"
-              th:object="${updateEmployeeForm}"
-            >
-              <fieldset>
-                <legend>従業員情報</legend>
-                <table class="table table-striped">
-                  <tr>
-                    <th nowrap>従業員名</th>
-                    <td>
-                      <span th:utext="${employee.name}">山田花子</span>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th nowrap>写真</th>
-                    <td>
-                      <img
-                        src="../../static/img/e2.png"
-                        th:src="${'/img/' + employee.image}"
-                      />
-                    </td>
-                  </tr>
-                  <tr>
-                    <th nowrap>性別</th>
-                    <td>
-                      <span th:utext="${employee.gender}">女性</span>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th nowrap>入社日</th>
-                    <td>
-                      <span th:utext="${employee.hireDate}">2012/11/29</span>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th nowrap>メールアドレス</th>
-                    <td>
-                      <span th:utext="${employee.mailAddress}"
-                        >yamada@sample.com</span
-                      >
-                    </td>
-                  </tr>
-                  <tr>
-                    <th nowrap>郵便番号</th>
-                    <td>
-                      <span th:utext="${employee.zipCode}">111-1111</span>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th nowrap>住所</th>
-                    <td>
-                      <span th:utext="${employee.address}"
-                        >東京都新宿区1-1-1</span
-                      >
-                    </td>
-                  </tr>
-                  <tr>
-                    <th nowrap>電話番号</th>
-                    <td>
-                      <span th:utext="${employee.telephone}"
-                        >090-0000-0000</span
-                      >
-                    </td>
-                  </tr>
-                  <tr>
-                    <th nowrap>給料</th>
-                    <td>
-                      <span th:utext="${employee.salary + '円'}">400000円</span>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th nowrap>特性</th>
-                    <td>
-                      <span th:utext="${employee.characteristics}"
-                        >明るく素直な性格です。リーダーシップを発揮します。新卒社員研修の時はグループ開発の時にリーダーを買ってでました。積極性も人間性も抜群です。周りに対する不満も聞いたことがありません。</span
-                      >
-                    </td>
-                  </tr>
-                  <tr>
-                    <th nowrap>扶養人数</th>
-                    <td>
-                      <label
-                        th:errors="*{dependentsCount}"
-                        class="error-messages"
-                      >
-                        扶養人数を入力してください
-                      </label>
-                      <label
-                        class="control-label"
-                        style="color: red"
-                        for="dependentsCount"
-                      ></label>
-                      <input
-                        type="hidden"
-                        name="id"
-                        th:value="${employee.id}"
-                      />
-                      <input
-                        type="text"
-                        name="dependentsCount"
-                        id="dependentsCount"
-                        class="form-control"
-                        value="3"
-                        th:errorclass="error-input"
-                        th:value="${employee.dependentsCount}"
-                      />
-                    </td>
-                  </tr>
-                </table>
-                <button type="submit" class="btn btn-primary">更新</button>
-              </fieldset>
-            </form>
+          <!-- ここにモックのform要素を貼り付けます -->
 
-            <!-- ここから下を編集する必要はありません -->
-          </div>
+          <form method="post" action="list.html" th:action="@{/employee/update}" th:object="${updateEmployeeForm}">
+            <fieldset>
+              <legend>従業員情報</legend>
+              <table class="table table-striped">
+                <tr>
+                  <th nowrap>従業員名</th>
+                  <td>
+                    <span th:utext="${employee.name}">山田花子</span>
+                  </td>
+                </tr>
+                <tr>
+                  <th nowrap>写真</th>
+                  <td>
+                    <img src="../../static/img/e2.png" th:src="${'/img/' + employee.image}" />
+                  </td>
+                </tr>
+                <tr>
+                  <th nowrap>性別</th>
+                  <td>
+                    <span th:utext="${employee.gender}">女性</span>
+                  </td>
+                </tr>
+                <tr>
+                  <th nowrap>入社日</th>
+                  <td>
+                    <span th:utext="${employee.hireDate}">2012/11/29</span>
+                  </td>
+                </tr>
+                <tr>
+                  <th nowrap>メールアドレス</th>
+                  <td>
+                    <span th:utext="${employee.mailAddress}">yamada@sample.com</span>
+                  </td>
+                </tr>
+                <tr>
+                  <th nowrap>郵便番号</th>
+                  <td>
+                    <span th:utext="${employee.zipCode}">111-1111</span>
+                  </td>
+                </tr>
+                <tr>
+                  <th nowrap>住所</th>
+                  <td>
+                    <span th:utext="${employee.address}">東京都新宿区1-1-1</span>
+                  </td>
+                </tr>
+                <tr>
+                  <th nowrap>電話番号</th>
+                  <td>
+                    <span th:utext="${employee.telephone}">090-0000-0000</span>
+                  </td>
+                </tr>
+                <tr>
+                  <th nowrap>給料</th>
+                  <td>
+                    <span th:utext="${employee.salary + '円'}">400000円</span>
+                  </td>
+                </tr>
+                <tr>
+                  <th nowrap>特性</th>
+                  <td>
+                    <span
+                      th:utext="${employee.characteristics}">明るく素直な性格です。リーダーシップを発揮します。新卒社員研修の時はグループ開発の時にリーダーを買ってでました。積極性も人間性も抜群です。周りに対する不満も聞いたことがありません。</span>
+                  </td>
+                </tr>
+                <tr>
+                  <th nowrap>扶養人数</th>
+                  <td>
+                    <label th:errors="*{dependentsCount}" class="error-messages">
+                      扶養人数を入力してください
+                    </label>
+                    <label class="control-label" style="color: red" for="dependentsCount"></label>
+                    <input type="hidden" name="id" th:value="${employee.id}" />
+                    <input type="text" name="dependentsCount" id="dependentsCount" class="form-control" value="3"
+                      th:errorclass="error-input" th:value="${employee.dependentsCount}" />
+                  </td>
+                </tr>
+              </table>
+              <button type="submit" class="btn btn-primary">更新</button>
+            </fieldset>
+          </form>
+
+          <!-- ここから下を編集する必要はありません -->
         </div>
       </div>
     </div>
-    <!-- end container -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="../../static/js/bootstrap.min.js"></script>
-  </body>
+  </div>
+  <!-- end container -->
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+  <script src="../../static/js/bootstrap.min.js"></script>
+</body>
+
 </html>

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -1,138 +1,101 @@
 <!DOCTYPE html>
-<html
-  lang="ja"
-  xmlns:th="http://www.thymeleaf.org"
-  xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
->
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>従業員管理システム</title>
-    <link
-      rel="stylesheet"
-      href="../../static/css/bootstrap.css"
-      th:href="@{/css/bootstrap.css}"
-    />
-    <link
-      rel="stylesheet"
-      href="../../static/css/style.css"
-      th:href="@{/css/style.css}"
-    />
-    <!--[if lt IE 9]>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>従業員管理システム</title>
+  <link rel="stylesheet" href="../../static/css/bootstrap.css" th:href="@{/css/bootstrap.css}" />
+  <link rel="stylesheet" href="../../static/css/style.css" th:href="@{/css/style.css}" />
+  <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
-  </head>
-  <body>
-    <div class="container">
-      <nav class="navbar navbar-default">
-        <div class="container-fluid">
-          <!-- Brand and toggle get grouped for better mobile display -->
-          <div class="navbar-header">
-            <button
-              type="button"
-              class="navbar-toggle collapsed"
-              data-toggle="collapse"
-              data-target="#bs-example-navbar-collapse-1"
-              aria-expanded="false"
-            >
-              <span class="sr-only">Toggle navigation</span>
-              <span class="icon-bar"></span> <span class="icon-bar"></span>
-              <span class="icon-bar"></span>
-            </button>
-            <a
-              class="navbar-brand"
-              href="list.html"
-              th:href="@{/employee/showList}"
-            >
-              <!-- 企業ロゴ -->
-              <img
-                src="../../static/img/header_logo_small.png"
-                th:src="@{/img/header_logo_small.png}"
-              />
-            </a>
-          </div>
+</head>
 
-          <!-- Collect the nav links, forms, and other content for toggling -->
-          <div
-            class="collapse navbar-collapse"
-            id="bs-example-navbar-collapse-1"
-          >
-            <ul class="nav navbar-nav">
-              <li class="active">
-                <a href="list.html" th:href="@{/employee/showList}"
-                  >従業員管理</a
-                >
-              </li>
-            </ul>
-            <p class="navbar-text navbar-right">
-              <span th:text="${administratorName}">山田太郎</span
-              >さんこんにちは！ &nbsp;&nbsp;&nbsp;
-              <a
-                href="../administrator/login.html"
-                class="navbar-link"
-                th:href="@{/logout}"
-                >ログアウト</a
-              >
-            </p>
-          </div>
-          <!-- /.navbar-collapse -->
+<body>
+  <div class="container">
+    <nav class="navbar navbar-default">
+      <div class="container-fluid">
+        <!-- Brand and toggle get grouped for better mobile display -->
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
+            data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span> <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class="navbar-brand" href="list.html" th:href="@{/employee/showList}">
+            <!-- 企業ロゴ -->
+            <img src="../../static/img/header_logo_small.png" th:src="@{/img/header_logo_small.png}" />
+          </a>
         </div>
-        <!-- /.container-fluid -->
-      </nav>
 
-      <!-- パンくずリスト -->
-      <ol class="breadcrumb">
-        <li class="active">
-          <a href="list.html" th:href="@{/employee/showList}">従業員リスト</a>
-        </li>
-      </ol>
-
-      <!-- table -->
-      <div class="row">
-        <div
-          class="table-responsive col-lg-offset-2 col-lg-8 col-md-offset-2 col-md-8 col-sm-12 col-xs-12"
-        >
-          <!-- ここから上を編集する必要はありません -->
-
-          <!-- ここにモックのtable要素を貼り付けます -->
-
-          <table class="table table-striped">
-            <thead>
-              <tr>
-                <th>従業員名</th>
-                <th>入社日</th>
-                <th>扶養人数</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr th:each="employee : ${employeeList}">
-                <td>
-                  <a
-                    href="detail.html"
-                    th:href="@{'/employee/showDetail?id=' + ${employee.id}}"
-                  >
-                    <span th:text="${employee.name}">山田太郎</span>
-                  </a>
-                </td>
-                <td>
-                  <span th:text="${employee.hireDate}">2016/12/1</span>
-                </td>
-                <td>
-                  <span th:text="${employee.dependentsCount} + '人'">3人</span>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-
-          <!-- ここから下を編集する必要はありません -->
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+          <ul class="nav navbar-nav">
+            <li class="active">
+              <a href="list.html" th:href="@{/employee/showList}">従業員管理</a>
+            </li>
+          </ul>
+          <p class="navbar-text navbar-right">
+            <span th:text="${session.administratorName}">山田太郎</span>さんこんにちは！ &nbsp;&nbsp;&nbsp;
+            <a href="../administrator/login.html" class="navbar-link" th:href="@{/logout}">ログアウト</a>
+          </p>
         </div>
+        <!-- /.navbar-collapse -->
+      </div>
+      <!-- /.container-fluid -->
+    </nav>
+
+    <!-- パンくずリスト -->
+    <ol class="breadcrumb">
+      <li class="active">
+        <a href="list.html" th:href="@{/employee/showList}">従業員リスト</a>
+      </li>
+    </ol>
+
+    <!-- table -->
+    <div class="row">
+      <div class="table-responsive col-lg-offset-2 col-lg-8 col-md-offset-2 col-md-8 col-sm-12 col-xs-12">
+        <!-- ここから上を編集する必要はありません -->
+
+        <!-- ここにモックのtable要素を貼り付けます -->
+
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>従業員名</th>
+              <th>入社日</th>
+              <th>扶養人数</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr th:each="employee : ${employeeList}">
+              <td>
+                <a href="detail.html" th:href="@{'/employee/showDetail?id=' + ${employee.id}}">
+                  <span th:text="${employee.name}">山田太郎</span>
+                </a>
+              </td>
+              <td>
+                <span th:text="${employee.hireDate}">2016/12/1</span>
+              </td>
+              <td>
+                <span th:text="${employee.dependentsCount} + '人'">3人</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <!-- ここから下を編集する必要はありません -->
       </div>
     </div>
-    <!-- end container -->
+  </div>
+  <!-- end container -->
 
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="../../static/js/bootstrap.min.js"></script>
-  </body>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+  <script src="../../static/js/bootstrap.min.js"></script>
+</body>
+
 </html>


### PR DESCRIPTION
## 概要 :bulb:

ログイン成功時に、セッションにユーザー名を格納し
従業員一覧画面と従業員詳細画面にユーザー名を表示させる。

## 観点 :eye:

コードに問題がないかの確認をお願いいたします。

## テスト :test_tube:

画面で、ログイン後に従業員一覧画面と従業員詳細画面に遷移し
それぞれユーザー名が表示されていることを確認。

## 関連する Issue :memo:

なし

## 補足情報 :notes:

なし