### PR TITLE
(3-1)従業員一覧の並び順を入社日の降順,メールアドレスの昇順で並び替え

### DIFF
--- a/src/main/java/com/example/repository/EmployeeRepository.java
+++ b/src/main/java/com/example/repository/EmployeeRepository.java
@@ -50,7 +50,7 @@ public class EmployeeRepository {
 	 * @return 全従業員一覧 従業員が存在しない場合はサイズ0件の従業員一覧を返します
 	 */
 	public List<Employee> findAll() {
-		String sql = "SELECT id,name,image,gender,hire_date,mail_address,zip_code,address,telephone,salary,characteristics,dependents_count FROM employees ORDER BY hire_date DESC,mail_address DESC";
+		String sql = "SELECT id,name,image,gender,hire_date,mail_address,zip_code,address,telephone,salary,characteristics,dependents_count FROM employees ORDER BY hire_date DESC,mail_address ASC";
 
 		List<Employee> developmentList = template.query(sql, EMPLOYEE_ROW_MAPPER);
 

--- a/src/main/java/com/example/repository/EmployeeRepository.java
+++ b/src/main/java/com/example/repository/EmployeeRepository.java
@@ -14,9 +14,9 @@ import com.example.domain.Employee;
 
 /**
  * employeesテーブルを操作するリポジトリ.
- * 
+ *
  * @author igamasayuki
- * 
+ *
  */
 @Repository
 public class EmployeeRepository {
@@ -46,11 +46,11 @@ public class EmployeeRepository {
 
 	/**
 	 * 従業員一覧情報を入社日順で取得します.
-	 * 
+	 *
 	 * @return 全従業員一覧 従業員が存在しない場合はサイズ0件の従業員一覧を返します
 	 */
 	public List<Employee> findAll() {
-		String sql = "SELECT id,name,image,gender,hire_date,mail_address,zip_code,address,telephone,salary,characteristics,dependents_count FROM employees";
+		String sql = "SELECT id,name,image,gender,hire_date,mail_address,zip_code,address,telephone,salary,characteristics,dependents_count FROM employees ORDER BY hire_date DESC,mail_address DESC";
 
 		List<Employee> developmentList = template.query(sql, EMPLOYEE_ROW_MAPPER);
 
@@ -59,7 +59,7 @@ public class EmployeeRepository {
 
 	/**
 	 * 主キーから従業員情報を取得します.
-	 * 
+	 *
 	 * @param id 検索したい従業員ID
 	 * @return 検索された従業員情報
 	 * @exception org.springframework.dao.DataAccessException 従業員が存在しない場合は例外を発生します


### PR DESCRIPTION
## 概要 :bulb:

従業員一覧画面の従業員表示において、現在の並び順が一定ではないため、
入社日の降順、メールアドレスの昇順に並び替えを実施。

## 観点 :eye:

コードに問題がないかの確認をお願いいたします。

## テスト :test_tube:

従業員一覧画面で、一覧が入社日の降順、メールアドレスの昇順に並び替えられていることを確認

## 関連する Issue :memo:

なし

## 補足情報 :notes:

並び順は、ユーザー利用の観点から入社日降順を基準にしています。
また今回はDate型のため、年月日までしか保持しておらず、どう入社日が存在する場合を想定してメールアドレスの昇順も追加しています。（こちらは竹森さんに確認済み）