### PR TITLE
(4-1) 従業員一覧と従業員詳細の日付フォーマットをyyyy年MM月dd日に変更

### DIFF
--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -89,7 +89,7 @@
                 <tr>
                   <th nowrap>入社日</th>
                   <td>
-                    <span th:utext="${employee.hireDate}">2012/11/29</span>
+                    <span th:utext="${#dates.format(employee.hireDate, 'yyyy年MM月dd日')}">2012/11/29</span>
                   </td>
                 </tr>
                 <tr>

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -79,7 +79,7 @@
                 </a>
               </td>
               <td>
-                <span th:text="${employee.hireDate}">2016/12/1</span>
+                <span th:text="${#dates.format(employee.hireDate, 'yyyy年MM月dd日')}">2016/12/1</span>
               </td>
               <td>
                 <span th:text="${employee.dependentsCount} + '人'">3人</span>


### PR DESCRIPTION
## 概要 :bulb:

従業員一覧と従業員詳細の日付フォーマットをyyyy年MM月dd日に変更する対応

## 観点 :eye:

コードに問題がないかの確認をお願いいたします。

## テスト :test_tube:

従業員一覧と従業員詳細を確認し、入社日項目がyyyy年MM月dd日形式に変更されていることを確認

## 関連する Issue :memo:

なし

## 補足情報 :notes:

なし