### PR TITLE
(4-2)従業員詳細画面：価格の表示を価格型(千の区切りにカンマ)にする対応

### DIFF
--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -119,7 +119,7 @@
                 <tr>
                   <th nowrap>給料</th>
                   <td>
-                    <span th:utext="${employee.salary + '円'}">400000円</span>
+                    <span th:utext="${#numbers.formatInteger(employee.salary, 0, 'COMMA') + '円'}">400000円</span>
                   </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
## 概要 :bulb:

従業員詳細画面の給料項目について、表示を価格型(千の区切りでカンマ)に修正する対応

## 観点 :eye:

コードに問題がないかの確認をお願いいたします。

## テスト :test_tube:

従業員詳細画面の給料項目が、価格型に変更されていることを確認

## 関連する Issue :memo:

なし

## 補足情報 :notes:

なし