### PR TITLE
(6-2)従業員の名前曖昧検索機能の追加

### DIFF
--- a/src/main/java/com/example/controller/EmployeeController.java
+++ b/src/main/java/com/example/controller/EmployeeController.java
@@ -18,7 +18,7 @@ import com.example.service.EmployeeService;
 
 /**
  * 従業員情報を操作するコントローラー.
- * 
+ *
  * @author igamasayuki
  *
  */
@@ -31,7 +31,7 @@ public class EmployeeController {
 
 	/**
 	 * 使用するフォームオブジェクトをリクエストスコープに格納する.
-	 * 
+	 *
 	 * @return フォーム
 	 */
 	@ModelAttribute
@@ -44,7 +44,7 @@ public class EmployeeController {
 	/////////////////////////////////////////////////////
 	/**
 	 * 従業員一覧画面を出力します.
-	 * 
+	 *
 	 * @param model モデル
 	 * @return 従業員一覧画面
 	 */
@@ -60,7 +60,7 @@ public class EmployeeController {
 	/////////////////////////////////////////////////////
 	/**
 	 * 従業員詳細画面を出力します.
-	 * 
+	 *
 	 * @param id    リクエストパラメータで送られてくる従業員ID
 	 * @param model モデル
 	 * @return 従業員詳細画面
@@ -77,7 +77,7 @@ public class EmployeeController {
 	/////////////////////////////////////////////////////
 	/**
 	 * 従業員詳細(ここでは扶養人数のみ)を更新します.
-	 * 
+	 *
 	 * @param form 従業員情報用フォーム
 	 * @return 従業員一覧画面へリダクレクト
 	 */
@@ -91,5 +91,27 @@ public class EmployeeController {
 		employee.setDependentsCount(form.getIntDependentsCount());
 		employeeService.update(employee);
 		return "redirect:/employee/showList";
+	}
+
+	/////////////////////////////////////////////////////
+	// ユースケース：従業員情報を名前で検索する(曖昧検索)
+	/////////////////////////////////////////////////////
+	/**
+	 * 従業員情報を検索します.
+	 *
+	 * @param name  従業員名
+	 * @param model モデル
+	 * @return 従業員詳細画面
+	 */
+	@GetMapping("/search")
+	public String search(String name, Model model) {
+		List<Employee> employeeList = employeeService.searchByName(name);
+		if (employeeList.size() == 0) {
+			model.addAttribute("message", "1件もありませんでした");
+			employeeList = employeeService.showList();
+		}
+
+		model.addAttribute("employeeList", employeeList);
+		return "employee/list";
 	}
 }

--- a/src/main/java/com/example/repository/EmployeeRepository.java
+++ b/src/main/java/com/example/repository/EmployeeRepository.java
@@ -83,4 +83,19 @@ public class EmployeeRepository {
 		String updateSql = "UPDATE employees SET dependents_count=:dependentsCount WHERE id=:id";
 		template.update(updateSql, param);
 	}
+
+	/**
+	 * 名前から従業員一覧情報を入社日の降順、メールアドレスの昇順で取得します.
+	 *
+	 * @param name 検索したい従業員名
+	 * @return 検索された従業員情報
+	 */
+	public List<Employee> findByName(String name) {
+		String sql = "SELECT id,name,image,gender,hire_date,mail_address,zip_code,address,telephone,salary,characteristics,dependents_count FROM employees WHERE name LIKE :name ORDER BY hire_date DESC,mail_address ASC";
+
+		SqlParameterSource param = new MapSqlParameterSource().addValue("name", "%" + name + "%");
+		List<Employee> employeeList = template.query(sql, param, EMPLOYEE_ROW_MAPPER);
+
+		return employeeList;
+	}
 }

--- a/src/main/java/com/example/service/EmployeeService.java
+++ b/src/main/java/com/example/service/EmployeeService.java
@@ -11,7 +11,7 @@ import com.example.repository.EmployeeRepository;
 
 /**
  * 従業員情報を操作するサービス.
- * 
+ *
  * @author igamasayuki
  *
  */
@@ -24,7 +24,7 @@ public class EmployeeService {
 
 	/**
 	 * 従業員情報を全件取得します.
-	 * 
+	 *
 	 * @return 従業員情報一覧
 	 */
 	public List<Employee> showList() {
@@ -34,7 +34,7 @@ public class EmployeeService {
 
 	/**
 	 * 従業員情報を取得します.
-	 * 
+	 *
 	 * @param id ID
 	 * @return 従業員情報
 	 * @throws org.springframework.dao.DataAccessException 検索されない場合は例外が発生します
@@ -46,10 +46,26 @@ public class EmployeeService {
 
 	/**
 	 * 従業員情報を更新します.
-	 * 
+	 *
 	 * @param employee 更新した従業員情報
 	 */
 	public void update(Employee employee) {
 		employeeRepository.update(employee);
+	}
+
+	/**
+	 * 名前が一致(曖昧)した従業員情報を取得します.
+	 *
+	 * @param name 従業員名
+	 * @return 従業員情報一覧
+	 */
+	public List<Employee> searchByName(String name) {
+		List<Employee> employeeList = null;
+		if (name.isBlank()) {
+			employeeList = showList();
+		} else {
+			employeeList = employeeRepository.findByName(name);
+		}
+		return employeeList;
 	}
 }

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -63,6 +63,17 @@
 
         <!-- ここにモックのtable要素を貼り付けます -->
 
+        <form class="input-group" th:action="@{/employee/search}">
+          <input type="text" id="txt-search" class="form-control input-group-prepend" placeholder="従業員名を入力"
+            name="name"></input>
+          <span class="input-group-btn input-group-append">
+            <button id="btn-search" class="btn btn-primary"><i class="fas fa-search"></i> 検索</button>
+          </span>
+        </form>
+
+        <br />
+
+        <div th:text="${message}"></div>
         <table class="table table-striped">
           <thead>
             <tr>


### PR DESCRIPTION
## 概要 :bulb:

従業員一覧画面に従業員名で曖昧検索する機能を追加。


**仕様**
- 空文字で検索した場合
　→全件検索結果を表示させる
- 指定した文字列が存在しなかった場合
　→「１件もありませんでした」というメッセージと共に全件検索結果を表示させる

## 観点 :eye:

コードに問題がないかの確認をお願いいたします。

## テスト :test_tube:

- 空文字で検索
空文字を入力し検索ボタンを押下
→全件検索結果が表示される

- 指定した文字列が存在しない場合
「ああああ」を入力し検索ボタンを押下
→「１件もありませんでした」というメッセージと共に全件検索結果が表示される

- 対象の従業員名を検索
「渡辺」と入力し検索ボタンを押下
→対象の渡辺さんが表示される

## 関連する Issue :memo:

なし

## 補足情報 :notes:

なし