### PR TITLE
(5-3)管理者ユーザのパスワードをハッシュ化する

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,10 +13,13 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/example/common/SecurityConfig.java
+++ b/src/main/java/com/example/common/SecurityConfig.java
@@ -1,0 +1,33 @@
+package com.example.common;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    protected SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.formLogin(login -> login
+                .loginProcessingUrl("/login")
+                .loginPage("/")
+                .defaultSuccessUrl("/employee/showList")
+                .failureUrl("/?result=error")
+                .usernameParameter("mailAddress")
+                .passwordParameter("password"));
+
+        return http.build();
+    }
+
+    @Bean
+    protected PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -3,6 +3,7 @@ package com.example.controller;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.annotation.Validated;
@@ -10,7 +11,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.example.domain.Administrator;
 import com.example.form.InsertAdministratorForm;
@@ -109,25 +109,11 @@ public class AdministratorController {
 	 * @return ログイン画面
 	 */
 	@GetMapping("/")
-	public String toLogin() {
-		return "administrator/login";
-	}
-
-	/**
-	 * ログインします.
-	 *
-	 * @param form 管理者情報用フォーム
-	 * @return ログイン後の従業員一覧画面
-	 */
-	@PostMapping("/login")
-	public String login(LoginForm form, RedirectAttributes redirectAttributes) {
-		Administrator administrator = administratorService.login(form.getMailAddress(), form.getPassword());
-		if (administrator == null) {
-			redirectAttributes.addFlashAttribute("errorMessage", "メールアドレスまたはパスワードが不正です。");
-			return "redirect:/";
+	public String toLogin(String result, Model model) {
+		if ("error".equals(result)) {
+			model.addAttribute("errorMessage", "メールアドレスまたはパスワードが不正です。");
 		}
-		session.setAttribute("administratorName", administrator.getName());
-		return "redirect:/employee/showList";
+		return "administrator/login";
 	}
 
 	/////////////////////////////////////////////////////

--- a/src/main/java/com/example/controller/EmployeeController.java
+++ b/src/main/java/com/example/controller/EmployeeController.java
@@ -3,6 +3,7 @@ package com.example.controller;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -13,8 +14,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.example.domain.Employee;
+import com.example.domain.LoginAdministrator;
 import com.example.form.UpdateEmployeeForm;
 import com.example.service.EmployeeService;
+
+import jakarta.servlet.http.HttpSession;
 
 /**
  * 従業員情報を操作するコントローラー.
@@ -28,6 +32,9 @@ public class EmployeeController {
 
 	@Autowired
 	private EmployeeService employeeService;
+
+	@Autowired
+	private HttpSession session;
 
 	/**
 	 * 使用するフォームオブジェクトをリクエストスコープに格納する.
@@ -49,7 +56,8 @@ public class EmployeeController {
 	 * @return 従業員一覧画面
 	 */
 	@GetMapping("/showList")
-	public String showList(Model model) {
+	public String showList(@AuthenticationPrincipal LoginAdministrator userDetails, Model model) {
+		session.setAttribute("administratorName", userDetails.getUsername());
 		List<Employee> employeeList = employeeService.showList();
 		model.addAttribute("employeeList", employeeList);
 		return "employee/list";

--- a/src/main/java/com/example/domain/LoginAdministrator.java
+++ b/src/main/java/com/example/domain/LoginAdministrator.java
@@ -1,0 +1,78 @@
+package com.example.domain;
+
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+/**
+ * ログイン情報に利用するドメイン
+ *
+ * @author T.Araki
+ */
+public class LoginAdministrator implements UserDetails {
+
+    private final Administrator administrator;
+
+    /** コンストラクタ */
+    public LoginAdministrator(Administrator administrator) {
+        this.administrator = administrator;
+    }
+
+    /**
+     * 今回は未使用
+     */
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    /**
+     * ハッシュ化済みのパスワードを返却
+     */
+    @Override
+    public String getPassword() {
+        return this.administrator.getPassword();
+    }
+
+    /**
+     * ユーザー名を返却
+     */
+    @Override
+    public String getUsername() {
+        return this.administrator.getName();
+    }
+
+    /**
+     * 今回は未使用
+     */
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    /**
+     * 今回は未使用
+     */
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    /**
+     * 今回は未使用
+     */
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    /**
+     * 今回は未使用
+     */
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/com/example/service/AdministratorService.java
+++ b/src/main/java/com/example/service/AdministratorService.java
@@ -1,6 +1,7 @@
 package com.example.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,12 +21,16 @@ public class AdministratorService {
 	@Autowired
 	private AdministratorRepository administratorRepository;
 
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+
 	/**
 	 * 管理者情報を登録します.
 	 *
 	 * @param administrator 管理者情報
 	 */
 	public void insert(Administrator administrator) {
+		administrator.setPassword(passwordEncoder.encode(administrator.getPassword()));
 		administratorRepository.insert(administrator);
 	}
 

--- a/src/main/java/com/example/service/LoginAdministratorDetailsService.java
+++ b/src/main/java/com/example/service/LoginAdministratorDetailsService.java
@@ -1,0 +1,38 @@
+package com.example.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.example.domain.Administrator;
+import com.example.domain.LoginAdministrator;
+import com.example.repository.AdministratorRepository;
+
+/**
+ * Spring Securityのログイン時に利用するUserDetailsServiceクラス
+ *
+ * @author T.Araki
+ */
+@Service
+public class LoginAdministratorDetailsService implements UserDetailsService {
+
+    @Autowired
+    private AdministratorRepository administratorRepository;
+
+    /**
+     * 入力されたメールアドレスが存在する場合は情報を返す
+     */
+    @Override
+    public UserDetails loadUserByUsername(String mailAddress) throws UsernameNotFoundException {
+        Administrator administrator = administratorRepository.findByMailAddress(mailAddress);
+
+        if (administrator == null) {
+            throw new UsernameNotFoundException(mailAddress);
+        }
+
+        return new LoginAdministrator(administrator);
+
+    }
+}


### PR DESCRIPTION
## 概要 :bulb:

spring securityを使用し管理者ユーザーのパスワードをハッシュ化する対応。

## 観点 :eye:

コードに問題がないかの確認をお願いいたします。

## テスト :test_tube:

登録されているパスワード情報がハッシュ化されているか。
問題なくログインできるか。
ユーザー名が表示されるか。

## 関連する Issue :memo:

なし

## 補足情報 :notes:

ユーザー情報をauthenticationで表示できなかったため、sessionで表示しています。
もし原因がわかればヒントをいただけますと幸いです。

html側では以下のように記載をしておりました。
<span sec:authentication="name"></span>

上記でできなかったため、以下も試しましたが表示されませんでした。
<span sec:authentication="principal.username"></span>