### PR TITLE
(5-4)ログイン認証フィルターを作成し、ログインしていない場合に操作を制限する

### DIFF
--- a/src/main/java/com/example/common/SecurityConfig.java
+++ b/src/main/java/com/example/common/SecurityConfig.java
@@ -20,7 +20,12 @@ public class SecurityConfig {
                 .defaultSuccessUrl("/employee/showList")
                 .failureUrl("/?result=error")
                 .usernameParameter("mailAddress")
-                .passwordParameter("password"));
+                .passwordParameter("password")
+                .permitAll());
+
+        http.authorizeHttpRequests(authz -> authz
+                .requestMatchers("/", "/toInsert", "/insert", "/css/**", "/img/**", "/js/**").permitAll()
+                .anyRequest().authenticated());
 
         return http.build();
     }

--- a/src/main/java/com/example/controller/EmployeeController.java
+++ b/src/main/java/com/example/controller/EmployeeController.java
@@ -18,11 +18,9 @@ import com.example.domain.LoginAdministrator;
 import com.example.form.UpdateEmployeeForm;
 import com.example.service.EmployeeService;
 
-import jakarta.servlet.http.HttpSession;
-
 /**
  * 従業員情報を操作するコントローラー.
- * 
+ *
  * @author igamasayuki
  *
  */
@@ -33,12 +31,9 @@ public class EmployeeController {
 	@Autowired
 	private EmployeeService employeeService;
 
-	@Autowired
-	private HttpSession session;
-
 	/**
 	 * 使用するフォームオブジェクトをリクエストスコープに格納する.
-	 * 
+	 *
 	 * @return フォーム
 	 */
 	@ModelAttribute
@@ -51,13 +46,12 @@ public class EmployeeController {
 	/////////////////////////////////////////////////////
 	/**
 	 * 従業員一覧画面を出力します.
-	 * 
+	 *
 	 * @param model モデル
 	 * @return 従業員一覧画面
 	 */
 	@GetMapping("/showList")
 	public String showList(@AuthenticationPrincipal LoginAdministrator userDetails, Model model) {
-		session.setAttribute("administratorName", userDetails.getUsername());
 		List<Employee> employeeList = employeeService.showList();
 		model.addAttribute("employeeList", employeeList);
 		return "employee/list";
@@ -68,7 +62,7 @@ public class EmployeeController {
 	/////////////////////////////////////////////////////
 	/**
 	 * 従業員詳細画面を出力します.
-	 * 
+	 *
 	 * @param id    リクエストパラメータで送られてくる従業員ID
 	 * @param model モデル
 	 * @return 従業員詳細画面
@@ -85,7 +79,7 @@ public class EmployeeController {
 	/////////////////////////////////////////////////////
 	/**
 	 * 従業員詳細(ここでは扶養人数のみ)を更新します.
-	 * 
+	 *
 	 * @param form 従業員情報用フォーム
 	 * @return 従業員一覧画面へリダクレクト
 	 */

--- a/src/main/resources/templates/administrator/insert.html
+++ b/src/main/resources/templates/administrator/insert.html
@@ -110,7 +110,7 @@
   </div>
   <!-- end container -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-  <script src="../../static/js/bootstrap.min.js"></script>
+  <script src="../../static/js/bootstrap.min.js" th:src="@{/js/bootstrap.min.js}"></script>
 </body>
 
 </html>

--- a/src/main/resources/templates/administrator/login.html
+++ b/src/main/resources/templates/administrator/login.html
@@ -1,101 +1,73 @@
 <!DOCTYPE html>
 <html lang="ja" xmlns:th="http://www.thymeleaf.org">
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>従業員管理システム</title>
-    <link
-      rel="stylesheet"
-      href="../../static/css/bootstrap.css"
-      th:href="@{/css/bootstrap.css}"
-    />
-    <link
-      rel="stylesheet"
-      href="../../static/css/style.css"
-      th:href="@{/css/style.css}"
-    />
-    <!--[if lt IE 9]>
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>従業員管理システム</title>
+  <link rel="stylesheet" href="../../static/css/bootstrap.css" th:href="@{/css/bootstrap.css}" />
+  <link rel="stylesheet" href="../../static/css/style.css" th:href="@{/css/style.css}" />
+  <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
-  </head>
-  <body>
-    <div class="container">
-      <!-- 上余白 -->
-      <div class="row">
-        <div class="col-lg-offset-0 col-lg-6 col-md-8 col-sm-10 col-xs-12">
-          <img
-            src="../../static/img/header_logo.png"
-            th:src="@{/img/header_logo.png}"
-          />
-        </div>
+</head>
+
+<body>
+  <div class="container">
+    <!-- 上余白 -->
+    <div class="row">
+      <div class="col-lg-offset-0 col-lg-6 col-md-8 col-sm-10 col-xs-12">
+        <img src="../../static/img/header_logo.png" th:src="@{/img/header_logo.png}" />
       </div>
-      <!-- login form -->
-      <div class="row">
-        <div
-          class="col-lg-offset-3 col-lg-6 col-md-offset-2 col-md-8 col-sm-10 col-xs-12"
-        >
-          <!-- 背景をグレーに、埋め込んだようなコンポーネント -->
-          <div class="well">
-            <!-- ここから上を編集する必要はありません -->
+    </div>
+    <!-- login form -->
+    <div class="row">
+      <div class="col-lg-offset-3 col-lg-6 col-md-offset-2 col-md-8 col-sm-10 col-xs-12">
+        <!-- 背景をグレーに、埋め込んだようなコンポーネント -->
+        <div class="well">
+          <!-- ここから上を編集する必要はありません -->
 
-            <!-- ここにモックのform要素を貼り付けます -->
+          <!-- ここにモックのform要素を貼り付けます -->
 
-            <form
-              method="post"
-              action="../employee/list.html"
-              th:action="@{/login}"
-            >
-              <fieldset>
-                <legend>ログイン</legend>
-                <div class="form-group">
-                  <div th:if="${errorMessage}" class="alert alert-danger">
-                    <p th:text="${errorMessage}">
-                      メールアドレスまたはパスワードが間違っています
-                    </p>
-                  </div>
+          <form method="post" action="../employee/list.html" th:action="@{/login}">
+            <fieldset>
+              <legend>ログイン</legend>
+              <div class="form-group">
+                <div th:if="${errorMessage}" class="alert alert-danger">
+                  <p th:text="${errorMessage}">
+                    メールアドレスまたはパスワードが間違っています
+                  </p>
                 </div>
-                <div class="form-group">
-                  <label for="mailAddress">メールアドレス:</label>
-                  <input
-                    type="text"
-                    name="mailAddress"
-                    id="mailAddress"
-                    class="form-control"
-                    placeholder="Email"
-                  />
-                </div>
-                <div class="form-group">
-                  <label for="inputPassword">パスワード:</label>
-                  <input
-                    type="password"
-                    name="password"
-                    id="inputPassword"
-                    class="form-control"
-                    placeholder="Password"
-                  />
-                </div>
-                <div class="form-group">
-                  <button type="submit" class="btn btn-primary">
-                    ログイン
-                  </button>
-                </div>
-                <div class="form-group">
-                  <a href="insert.html" th:href="@{/toInsert}"
-                    >管理者登録はこちらから</a
-                  >
-                </div>
-              </fieldset>
-            </form>
+              </div>
+              <div class="form-group">
+                <label for="mailAddress">メールアドレス:</label>
+                <input type="text" name="mailAddress" id="mailAddress" class="form-control" placeholder="Email" />
+              </div>
+              <div class="form-group">
+                <label for="inputPassword">パスワード:</label>
+                <input type="password" name="password" id="inputPassword" class="form-control" placeholder="Password" />
+              </div>
+              <div class="form-group">
+                <button type="submit" class="btn btn-primary">
+                  ログイン
+                </button>
+              </div>
+              <div class="form-group">
+                <a href="insert.html" th:href="@{/toInsert}">管理者登録はこちらから</a>
+              </div>
+            </fieldset>
+          </form>
 
-            <!-- ここから下を編集する必要はありません -->
-          </div>
+          <!-- ここから下を編集する必要はありません -->
         </div>
       </div>
     </div>
-    <!-- end container -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="../../static/js/bootstrap.min.js"></script>
-  </body>
+  </div>
+  <!-- end container -->
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+  <script src="../../static/js/bootstrap.min.js" th:src="@{/js/bootstrap.min.js}"></script>
+</body>
+
 </html>

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -155,7 +155,7 @@
   </div>
   <!-- end container -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-  <script src="../../static/js/bootstrap.min.js"></script>
+  <script src="../../static/js/bootstrap.min.js" th:src="@{/js/bootstrap.min.js}"></script>
 </body>
 
 </html>

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -40,7 +40,7 @@
             </li>
           </ul>
           <p class="navbar-text navbar-right">
-            <span th:text="${session.administratorName}">山田太郎</span>さんこんにちは！ &nbsp;&nbsp;&nbsp;
+            <span sec:authentication="name">山田太郎</span>さんこんにちは！ &nbsp;&nbsp;&nbsp;
             <a href="../administrator/login.html" class="navbar-link" th:href="@{/logout}">ログアウト</a>
           </p>
         </div>

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -95,7 +95,7 @@
   <!-- end container -->
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-  <script src="../../static/js/bootstrap.min.js"></script>
+  <script src="../../static/js/bootstrap.min.js" th:src="@{/js/bootstrap.min.js}"></script>
 </body>
 
 </html>

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -40,7 +40,7 @@
             </li>
           </ul>
           <p class="navbar-text navbar-right">
-            <span th:text="${session.administratorName}">山田太郎</span>さんこんにちは！ &nbsp;&nbsp;&nbsp;
+            <span sec:authentication="name">山田太郎</span>さんこんにちは！ &nbsp;&nbsp;&nbsp;
             <a href="../administrator/login.html" class="navbar-link" th:href="@{/logout}">ログアウト</a>
           </p>
         </div>


### PR DESCRIPTION
## 概要 :bulb:

spring securityでログインフィルター機能を追加。
ログインしていない場合、ログイン画面表示、管理者追加画面表示、管理者追加のみ可能とする。

## 観点 :eye:

コードに問題がないかの確認をお願いいたします。

## テスト :test_tube:

ログインしていない状態で、「http://localhost:8080/employee/showList」と「http://localhost:8080/employee/showDetail?id=7」にアクセスするとログイン画面に遷移すること。

ログイン状態で「http://localhost:8080/employee/showList」と「http://localhost:8080/employee/showDetail?id=7」にアクセスすると問題なく画面遷移できること。

## 関連する Issue :memo:

なし

## 補足情報 :notes:

なし